### PR TITLE
Update to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ If you are starting a new project in AWS it is sometimes necessary to have a wor
 Other option is to set AWS SES Email receiving rule. 
 
 ## How to 
+* Set up custom domain through Route53 (beyond the scope of this document)
+* Add an MX record in Route53 to point to an AWS mailserver. Region (e.g. us-east-1) must match region used in each step below.
+* Verify the email address you will be forwarding to in SES (Identity Management > Email Addresses)
 * Set up SNS
   * SNS > Create topic > Enter "email-forwarding" or name of your choice for topic name
   
@@ -21,20 +24,22 @@ Other option is to set AWS SES Email receiving rule.
  * Next step > Create Rule
  
 * Make your lambda function
-  * Lambda > Create Lambda Function > Blank Function > Next
-  * Select SNS trigger (click on dashed square left of Lambda icon) > select SNS
-  * SNS topic > select your SNS topic that you created earlier
-  * Check Enable trigger
+  * Lambda > Create Lambda Function > "Author from scratch"
   * Name it SES_Email_Forward or name of your choice
-  * Runtime Node 4.3
-  * Copy the code from mail_forward.js to lambda function code
-  * Set environment variable fwd_address to email address that you want your emails forwarded to
-  * Handler should be index.handler
+  * Runtime Node 6.10
   * Role: create custom role > new page will open
     * IAM Role > Create a new IAM Role
     * Role name > lambda_email_forward or enter name of your choice
     * View Policy Document > Edit
     * Copy and replace existing JSON with JSON from mail_forward_policy.json
     * Allow
-  * Next > Create function
+  * Create function
+  * On the Configuration page for your new function:
+    * Select SNS trigger (click on dashed square left of the root Lambda function tree) > select SNS
+      * SNS topic > select your SNS topic that you created earlier
+      * Check Enable trigger
+    * Click on the root Lambda function, scroll down to Function code
+      * Copy the code from mail_forward.js to lambda function code
+      * Set environment variable to_address to email address that you want your emails forwarded to
+      * Handler should be index.handler
   


### PR DESCRIPTION
- Added some earlier setup steps that weren't immediately obvious to me at first (primarily the need to add the MX record).
- Must verify email addr you'll be forwarding to in SES otherwise it won't relay it.
- Lambda creation process is slightly different now.
- Lambda script is expecting "to_address" not "fwd_address".
- Could not get the lambda script to run in Node 4.3; debugging showed a syntax error:
Syntax error in module 'index': SyntaxError
at Module._compile (module.js:373:25)
at Object.Module._extensions..js (module.js:416:10)
at Module.load (module.js:343:32)
at Function.Module._load (module.js:300:12)
at Module.require (module.js:353:17)
at require (internal/module.js:12:17)